### PR TITLE
Support field aliases and a keyword transform function

### DIFF
--- a/src/graphql_client/core.clj
+++ b/src/graphql_client/core.clj
@@ -2,30 +2,38 @@
 
 (declare args->str)
 
-(defn arg->str [v]
-  (cond (map? v) (str "{" (args->str v) "}")
-        (keyword? v) (str "\"" (name v) "\"")
-        (string? v) (str "\"" v "\"")
-        (coll? v) (str "[" (apply str (interpose "," (map arg->str v))) "]")
-        :else (str v)))
+(defn arg->str
+  ([v] (arg->str name v))
+  ([kw-xform v]
+   (cond (map? v) (str "{" (args->str kw-xform v) "}")
+         (keyword? v) (str "\"" (kw-xform v) "\"")
+         (string? v) (str "\"" v "\"")
+         (coll? v) (str "[" (apply str (interpose "," (map (partial arg->str kw-xform) v))) "]")
+         :else (str v))))
 
-(defn args->str [m]
-  (->> (for [[k v] m]
-         [(name k) ":" (arg->str v)])
-       (interpose ",")
-       (flatten)
-       (apply str)))
+(defn args->str
+  ([m] (args->str name m))
+  ([kw-xform m]
+   (->> (for [[k v] m]
+          [(kw-xform k) ":" (arg->str kw-xform v)])
+        (interpose ",")
+        (flatten)
+        (apply str))))
 
-(defn query->str [q]
-  (if (keyword? q)
-    (name q)
-    (let [f (first q)
-          s (second q)
-          r (if (map? s) (drop 2 q) (rest q))]
-      (println f s r)
-      (apply str (flatten (cond (keyword? f) [(name f)
-                                              (if (map? s) ["(" (args->str s) ")"] "")
-                                              (when (seq r) ["{" (interpose " " (map query->str r)) "}"])]
-                                (vector? f) ["{" (map query->str q) "}"]
-                                :else "")))
-      )))
+(defn query->str
+  ([q] (query->str name q))
+  ([kw-xform q]
+   (if (keyword? q)
+     (kw-xform q)
+     (let [f (first q)
+           s (second q)
+           r (if (map? s) (drop 2 q) (rest q))]
+       (apply str (flatten (cond (or (keyword? f)
+                                     (map? f)) [(if (map? f)
+                                                  [(kw-xform (ffirst f)) ":" (kw-xform (second (first f)))]
+                                                  (kw-xform f))
+                                                (if (map? s) ["(" (args->str kw-xform s) ")"] "")
+                                                (when (seq r) ["{" (interpose " " (map (partial query->str kw-xform) r)) "}"])]
+                                 (vector? f) ["{" (map (partial query->str kw-xform) q) "}"]
+                                 :else "")))
+       ))))

--- a/test/graphql_client/core_test.clj
+++ b/test/graphql_client/core_test.clj
@@ -1,4 +1,5 @@
-(ns graphql-client.core
+(ns graphql-client.core-test
+  (:require [graphql-client.core :refer :all])
   (:use [clojure.test]))
 
 (deftest arg->str-test []
@@ -24,5 +25,6 @@
   (is (= "{q}" (query->str [[:q]])))
   (is (= "{q{a}}" (query->str [[:q :a]])))
   (is (= "{q{a b}}" (query->str [[:q :a :b]])))
-  (is (= "{q{a}}" (query->str [[:q :a]]))))
-
+  (is (= "{a1:q{a}}" (query->str [[{:a1 :q} :a]])))
+  (is (= "{q{a1:a{b}}}" (query->str [[:q [{:a1 :a} :b]]])))
+  (is (= "{Q{B}}" (query->str (fn [kw] ((comp (memfn toUpperCase) name) kw)) [[:q :b]]))))


### PR DESCRIPTION
@Macroz 

- Adds field aliases if a map is provided as the first arg of a vector (uses only the first map entry)
- Take an optional keyword xform function so you can (for instance) specify all keywords in Clojure-style kebab-case but transform to camelCase or snake_case in the rendered query